### PR TITLE
addReduxStore returns store

### DIFF
--- a/client/reactotron/client.js
+++ b/client/reactotron/client.js
@@ -145,6 +145,8 @@ client.addReduxStore = (store) => {
   client.onCommand('redux.dispatch', (action, client) => {
     store.dispatch(action.action)
   })
+
+  return store
 }
 
 client.hookErrors = () => {


### PR DESCRIPTION
When I originally read the docs, I did not think `addReduxStore` was modifying `store` which is a const.  Most people will probably see a const as non-changing, even though we know in many ways it can, _like here_.

With this PR people don't have to know.  If they `return store` or if they return `return Reactotron.addReduxStore(store)` both will work.   Dynamic syntax to allow for interpretive implementation.