### PR TITLE
Add ImmutableJS support via client.addImutableReduxStore()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ import Reactotron from 'reactotron'
 
 const store = createStore(...)  // however you create your store
 Reactotron.addReduxStore(store) // <--- here i am!
+
+// Or if you're using ImmutableJS
+
+Reactotron.addImmutableReduxStore(store) // <--- It's immutable!
 ```
 
 ### API Tracking (optional)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "docdash": "^0.1.0",
+    "fbjs": "^0.8.1",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-rollup": "^1.8.0",


### PR DESCRIPTION
Fixes #18

This adds a new method called `Client.addImmutableReduxStore()`. It is a fairly almost duplicate version of `addReduxStore` but handles calling the ImmutableJS methods.

I feel like it could be cleaned up a bit, especially if moving towards just using the middleware as described in #15 so let me know what can be improved!

I also added `fbjs` to devDependencies as it seems we were relying on it? :)