### PR TITLE
Add import statement to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Reactotron.connect()
 
 ```js
 // wherever you create your Redux store, add the Reactotron middleware:
+import Reactotron from 'reactotron'
 
 const store = createStore(
   rootReducer,


### PR DESCRIPTION
Minor tweak to one of the examples in the README. I probably should have known to do that `import` without the docs in the example, but I am a big dummy.