### PR TITLE
Add Reactotron.storeEnhancer alternative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Reactotron.connect()
 
 ```js
 // wherever you create your Redux store, add the Reactotron middleware:
+
 import Reactotron from 'reactotron'
 
 const store = createStore(
@@ -91,6 +92,19 @@ const store = createStore(
     logger,
     Reactotron.reduxMiddleware // <--- here i am!
   )
+)
+
+// Or you can use the Reactotron storeEnhancer!
+
+const enhancer = compose(
+  // If you have other enhancers..
+  Reactotron.storeEnhancer()
+)
+
+const store = createStore(
+  rootReducer,
+  initialState,
+  enhancer
 )
 
 ```
@@ -113,6 +127,9 @@ import Reactotron from 'reactotron'
 
 const store = createStore(...)  // however you create your store
 Reactotron.addReduxStore(store) // <--- here i am!
+
+// If you're using the Reactotron.storeEnhance(), it's already
+// setup for you!
 ```
 
 ### API Tracking (optional)

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -83,7 +83,7 @@ client.sendCommand = (type, message) => {
   }
 }
 
-client.addReduxStore = (store) => {
+client.createSubscriptionListener = (store) => {
   let subscriptions = []
 
   // send the subscriptions to the client
@@ -118,7 +118,11 @@ client.addReduxStore = (store) => {
     sendSubscriptions()
   })
 
-  store.subscribe(sendSubscriptions)
+  return sendSubscriptions
+}
+
+client.addReduxStore = (store) => {
+  store.subscribe(client.createSubscriptionListener(store))
 
   // return the store at the given path
   client.onCommand('redux.value.request', (action, client) => {
@@ -173,16 +177,57 @@ client.hookErrors = () => {
   }
 }
 
-const MIDDLEWARE_ACTION_IGNORE = ['EFFECT_TRIGGERED', 'EFFECT_RESOLVED', 'EFFECT_REJECTED']
-
-client.reduxMiddleware = (store) => (next) => (action) => {
+// Returns a function that can track performance.
+client.trackPerformance = (action) => {
   const {type} = action
   const start = performanceNow()
-  const result = next(action)
-  const ms = (performanceNow() - start).toFixed(0)
-  if (!R.contains(action.type, MIDDLEWARE_ACTION_IGNORE)) {
-    client.sendCommand('redux.action.done', {type, ms, action})
+
+  const stopTracking = () => {
+    const ms = (performanceNow() - start).toFixed(0)
+
+    if (!R.contains(action.type, MIDDLEWARE_ACTION_IGNORE)) {
+      client.sendCommand('redux.action.done', {type, ms, action})
+    }
   }
+
+  return stopTracking
+}
+
+const MIDDLEWARE_ACTION_IGNORE = ['EFFECT_TRIGGERED', 'EFFECT_RESOLVED', 'EFFECT_REJECTED']
+
+// Enhances the store by wrapping the main reducer
+// with our own reduxReducer, as well as setting up
+// the store listener.
+client.storeEnhancer = () => {
+  return next => (reducer, initialState, enhancer) => {
+    const wrappedReducer = (state, action) => {
+      // Begin tracking performance.
+      const performanceTracker = client.trackPerformance(action)
+
+      // Run the main reducer.
+      const result = reducer(state, action)
+
+      // Stop tracking performance.
+      performanceTracker()
+
+      return result
+    }
+
+    const store = next(wrappedReducer, initialState, enhancer)
+
+    return client.addReduxStore(store)
+  }
+}
+
+client.reduxMiddleware = (store) => (next) => (action) => {
+  // Begin tracking performance.
+  const performanceTracker = client.trackPerformance(action)
+
+  const result = next(action)
+
+  // Stop tracking performance.
+  performanceTracker()
+
   return result
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
 const Client = require('./dist/client')
 
 module.exports = Client
-


### PR DESCRIPTION
This removes the need to add the middleware and also manually call `Reactotron.addReduxStore(store)` by using a store enhancer.

So setting up the Redux support should be as easy as:

```js
import { createStore, compose } from 'redux'
import Reactotron from 'reactotron'

const enhancer = compose(
  // If you have other enhancers or middleware..
  Reactotron.storeEnhancer()
)

const store = createStore(
  rootReducer,
  initialState,
  enhancer
)
```

I tried to keep compatibility with the original workflow, but I've split up the methods to be a bit more reusable. Let me know what you think. The performance tracking seems to be off, but I may have done something silly when I tried to clean it up. This is also still my first week learning Redux. 😁 