### PR TITLE
Master switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ Might be worth creating an alias or adding it to your script section of your `pa
 
 # How To Use
 
-Remember, this is a development tool.  It'll help you build your app.  But you don't want to ship
-your product with this left on.  :)
-
 To use this, you need to add a few lines of code to your app.
 
 Depending on how much support you'd like, there's a few different places you'll want to hook in.
@@ -67,7 +64,14 @@ If you have `index.ios.js` or `index.android.js`, you can place this code somewh
 ```js
 import Reactotron from 'reactotron'
 
+// connect with defaults
 Reactotron.connect()
+```
+
+I'd recommend using the following for connect in React Native so that release builds will disable reactotron.
+
+```js
+Reactotron.connect({enabled: __DEV__})
 ```
 
 ### Redux Middleware (optional)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ the right TCP port to the `reactotron` server.
 
 When you initialize the `reactotron` you can tell it the server location when you connect:
 
-`Reactotron.connect('10.0.1.109')`
+`Reactotron.connect({server: '10.0.1.109'})`
 
 ##### Useful shortcuts
 
@@ -209,7 +209,7 @@ Be sure to read the silly `examples/README.md` file for more details.
 
 # Special Thanks
 
-A shout out to my teammates at [Infinite Red](https://infinite.red) who encourage this type of open-source hacking & sharing.  
+A shout out to my teammates at [Infinite Red](https://infinite.red) who encourage this type of open-source hacking & sharing.
 
 [<img src='https://infinite.red/images/ir-logo-7ebf9ed9d02e2805bb2c94309efa5176.svg' />](https://infinite.red)
 

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -98,6 +98,9 @@ client.sendCommand = (type, message) => {
 }
 
 client.addReduxStore = (store) => {
+  // shortcircuit if disabled
+  if (!reactotronEnabled) return store
+
   let subscriptions = []
 
   // send the subscriptions to the client

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -44,12 +44,12 @@ client.onCommand('devMenu.reload', (action, client) => {
   Connect to the server.
   @param {Object} [{server: 'localhost', port: 3334, enabled: true}]
  */
-client.connect = (c = {}) => {
+client.connect = (userConfigurations = {}) => {
   const defaults = {server: 'localhost', port: 3334, enabled: true}
   // merge user input with defaults
   const config = {
     ...defaults,
-    ...c
+    ...userConfigurations
   }
 
   if (config.enabled) {

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -42,24 +42,32 @@ client.onCommand('devMenu.reload', (action, client) => {
 
 /**
   Connect to the server.
-  @param {String} server The server to connect to.
-  @param {Number} port The port to use (default 3334)
+  @param {Object} [{server: 'localhost', port: 3334, enabled: true}]
  */
-client.connect = (server = 'localhost', port = 3334) => {
-  socket = io(`ws://${server}:${port}`, {
-    jsonp: false,
-    transports: ['websocket']
-  })
-  socket.on('connect', () => {
-    client.log('connected')
-  })
-  socket.on('command', (data) => {
-    const action = JSON.parse(data)
-    const {type} = action
-    const handlers = commandHandlers[type] || []
-    R.forEach((handler) => { handler(action, client) }, handlers)
-  })
-  client.hookErrors()
+client.connect = (c = {}) => {
+  const defaults = {server: 'localhost', port: 3334, enabled: true}
+  // merge user input with defaults
+  const config = {
+    ...defaults,
+    ...c
+  }
+
+  if (config.enabled) {
+    socket = io(`ws://${config.server}:${config.port}`, {
+      jsonp: false,
+      transports: ['websocket']
+    })
+    socket.on('connect', () => {
+      client.log('connected')
+    })
+    socket.on('command', (data) => {
+      const action = JSON.parse(data)
+      const {type} = action
+      const handlers = commandHandlers[type] || []
+      R.forEach((handler) => { handler(action, client) }, handlers)
+    })
+    client.hookErrors()
+  }
 }
 
 /**


### PR DESCRIPTION
This has a breaking change, in that connect params are now a user configuration object.

This PR allows `Reactotron.connect({enabled: __DEV__})` for allowing Reactotron to remain benign in shipped builds.