### PR TITLE
Fixes up the action timer and race condition with the configuration.

### DIFF
--- a/examples/ReactDomExample/App/Config/ReactotronConfig.js
+++ b/examples/ReactDomExample/App/Config/ReactotronConfig.js
@@ -1,0 +1,7 @@
+import Reactotron from '../../client' // in a real app, you would use 'reactotron'
+
+Reactotron.connect({
+  enabled: true,
+  name: 'ReactDomExample'
+})
+

--- a/examples/ReactDomExample/App/index.js
+++ b/examples/ReactDomExample/App/index.js
@@ -1,10 +1,9 @@
+// imported from a file to ensure the connect statement gets run first!
+import './Config/ReactotronConfig'
 import { AppContainer } from 'react-hot-loader'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
-import Reactotron from '../client'
-
-Reactotron.connect()
 
 const rootEl = document.getElementById('root')
 ReactDOM.render(

--- a/examples/ReactNativeExample/App/Config/ReactotronConfig.js
+++ b/examples/ReactNativeExample/App/Config/ReactotronConfig.js
@@ -1,0 +1,9 @@
+import Reactotron from '../../client' // in a real app, you would use 'reactotron'
+import {Platform} from 'react-native'
+
+Reactotron.connect({
+  enabled: true,
+  name: 'ReactNativeExample',
+  userAgent: Platform.OS
+})
+

--- a/examples/ReactNativeExample/App/Store/Store.js
+++ b/examples/ReactNativeExample/App/Store/Store.js
@@ -19,16 +19,13 @@ const logger = createLogger({
 
 // a function which can create our store and auto-persist the data
 export default () => {
-  const enhancer = compose(Reactotron.storeEnhancer())
-
-  const store = createStore(
-    rootReducer,
+  const enhancer = compose(
     applyMiddleware(
       logger,
       sagaMiddleware(...sagas)
     ),
-    enhancer
+    Reactotron.storeEnhancer()
   )
 
-  return store
+  return createStore(rootReducer, enhancer)
 }

--- a/examples/ReactNativeExample/index.android.js
+++ b/examples/ReactNativeExample/index.android.js
@@ -1,8 +1,7 @@
+// imported from a file to ensure the connect statement gets run first!
+import './App/Config/ReactotronConfig'
 import React, { AppRegistry, Component } from 'react-native'
 import ReduxContainer from './App/Containers/ReduxContainer'
-import Reactotron from './client' // in a real app, you would use 'reactotron'
-
-Reactotron.connect({enabled: true})
 
 class ReactNativeExample extends Component {
   render () {

--- a/examples/ReactNativeExample/index.ios.js
+++ b/examples/ReactNativeExample/index.ios.js
@@ -1,8 +1,7 @@
+// imported from a file to ensure the connect statement gets run first!
+import './App/Config/ReactotronConfig'
 import React, { AppRegistry, Component } from 'react-native'
 import ReduxContainer from './App/Containers/ReduxContainer'
-import Reactotron from './client' // in a real app, you would use 'reactotron'
-
-Reactotron.connect({enabled: true, name: 'Hello'})
 
 class ReactNativeExample extends Component {
   render () {

--- a/examples/ReactNativeWebExample/App/Config/ReactotronConfig.js
+++ b/examples/ReactNativeWebExample/App/Config/ReactotronConfig.js
@@ -1,0 +1,6 @@
+import Reactotron from '../../client' // in a real app, you would use 'reactotron'
+
+Reactotron.connect({
+  enabled: true,
+  name: 'ReactNativeWebExample'
+})

--- a/examples/ReactNativeWebExample/index.web.js
+++ b/examples/ReactNativeWebExample/index.web.js
@@ -1,8 +1,7 @@
+// imported from a file to ensure the connect statement gets run first!
+import './App/Config/ReactotronConfig'
 import React, { AppRegistry, Component } from 'react-native'
 import ReduxContainer from './App/Containers/ReduxContainer'
-import reactotron from './client'
-
-reactotron.connect()
 
 class TestClient extends Component {
   render () {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf bin dist",
     "gulp": "gulp build",
     "start": "babel-node server/index.js",
-    "cpc2ex": "cp dist/client.js examples/ReactDomExample/ && cp dist/client.js examples/ReactNativeExample/ && cp dist/client.js examples/ReactNativeWebExample/"
+    "cpc2ex": "rm examples/ReactDomExample/client.js && cp dist/client.js examples/ReactDomExample/ && rm examples/ReactNativeExample/client.js && cp dist/client.js examples/ReactNativeExample/ && rm examples/ReactNativeWebExample/client.js && cp dist/client.js examples/ReactNativeWebExample/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two bugs fixed here.

First was the store enhancer wasn't truly timing the action.  It was timing the ability to dispatch a reducer asynchronously.  Which is always pretty damn quick!

The other is crazysauce.  It is important that Reactotron be `connect()`ed before your store is created, otherwise you don't have the correct settings.

The best way to do this is to move the `Reactotron.connect()` into a file.  Then its possible to drive the import order yourself.  That way you'll always call `connect()` before your redux store gets created.

Check out the 3 examples for more info.

Fixes #38 