### PR TITLE
Get correctly localhost for Android emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,6 @@ You can also register steps if you're timing a sequence.
 
 # Tips
 
-##### Using With Android
-
-If you're using an Android sim and it's running 5.x or higher, you can use `adb` to port forward
-the right TCP port to the `reactotron` server.
-
-`$ANDROID_HOME/platform-tools/adb reverse tcp:3334 tcp:3334`
-
 ##### Using On A Device
 
 When you initialize the `reactotron` you can tell it the server location when you connect:

--- a/client/client.js
+++ b/client/client.js
@@ -46,6 +46,27 @@ client.onCommand('devMenu.reload', (action, client) => {
   // devMenu && devMenu.reload()
 })
 
+/*
+ * Get React Native server IP if hostname is `localhost`
+ * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)
+ */
+function getHost(hostname) {
+  if (
+    (hostname === 'localhost' || hostname === '127.0.0.1') &&
+    typeof window !== 'undefined' &&
+    window.__fbBatchedBridge &&
+    window.__fbBatchedBridge.RemoteModules &&
+    window.__fbBatchedBridge.RemoteModules.AndroidConstants
+  ) {
+    const {
+      ServerHost = hostname
+    } = window.__fbBatchedBridge.RemoteModules.AndroidConstants;
+    return ServerHost.split(':')[0];
+  }
+
+  return hostname;
+}
+
 /**
   Connect to the server.
   @param userConfigurations Client configuration for connecting to Reactotron
@@ -66,7 +87,8 @@ client.connect = (userConfigurations = {}) => {
   // merge user input with defaults
   const config = {
     ...defaults,
-    ...userConfigurations
+    ...userConfigurations,
+    server: getHost(userConfigurations.server || defaults.server)
   }
 
   // keep track for all ops


### PR DESCRIPTION
Use `NativeModules.AndroidConstants` to get correctly localhost `10.0.2.2` (Genymotion: `10.0.3.2`) for Android emulator.

It mean we will never need use `add reverse` for Android emulator.