### PR TITLE
Sidesteps React Native internal dependency issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+lerna-debug.log

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,56 @@
+# Contributing
+
+### Getting Started
+
+Clone & switch to the right branch.
+
+```
+git clone git@github.com:skellock/reactotron.git
+cd reactotron
+git checkout next
+```
+
+Run the setup script to install the dependencies & run tests.
+
+```
+npm run welcome
+```
+
+
+### Code Style
+
+We use [standard.js](https://github.com/feross/standard).  It is passive-agressively enforced.
+Stern looks will be handed out.  For repeat offenders, there WILL be finger wagging.
+
+
+### Monorepo & Lerna
+
+This is a monorepo: multiple JS packages in 1 git repo.
+
+We use [lerna](https://github.com/lerna/lerna) to help us.
+
+
+### Funky internal dependencies
+
+`demo-react-native` is a React Native sample app.  It depends on
+`reactotron-react-native` which in turn depends on both `socket.io` and
+`reactotron-core-client`.
+
+Usually npm handles this right?
+
+So why am I typing this?
+
+Well, React Native (<=0.30.0) makes this hard to link to the dependencies
+within this repo.
+
+How we current get around this is by:
+
+1. adding `socket.io` to the deps of `demo-react-native` :(
+1. copy built versions of `reactotron-core-client` and `reactotron-react-native` manually to `node_modules` :(
+
+Many tears were shed and this is the least shitty solution I could muster.
+
+In the root, you can run `npm copy-internal-deps` to make them copy over.
+
+But since you're copying built dependencies, you'll need to run `npm run build` first
+if you're doing this to bring forward changes in those dependency libraries.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,12 @@
 {
+  "scripts": {
+    "bootstrap": "lerna bootstrap",
+    "build": "lerna run build",
+    "clean": "lerna clean",
+    "test": "lerna run test",
+    "copy-internal-deps": "lerna run copy-internal-deps",
+    "welcome": "./scripts/welcome.sh"
+  },
   "devDependencies": {
     "lerna": "2.0.0-beta.24"
   }

--- a/packages/demo-react-native/README.md
+++ b/packages/demo-react-native/README.md
@@ -1,15 +1,11 @@
 # React Native + Reactotron Demo
 
-Heads up.  As of React Native, we still can't use symlinks, which makes for
-ugly nested dependencies.
+### About the dependencies
 
-So we can't use `react native link`.
+`socket.io` is installed as a dependency because `reactotron-react-native` is
+not installed quite the same as the other dependencies for this repo only.
 
-Also, we can't use `lerna bootstrap` because the dependency lives outside
-the packager root.
+You won't have this requirement on your own projects.  This is only important
+for those of you who want to run this demo within this project.
 
-That, we might be able to fix... not quite sure yet.
-
-In the meantime... enjoy my absolute paths.
-
-You can run `./hacksetup` to sub your own.  Sigh.
+Cobbler's shoes.  Or something.

--- a/packages/demo-react-native/copy-internal-deps.sh
+++ b/packages/demo-react-native/copy-internal-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cp ../reactotron-react-native/dist/index.js node_modules/reactotron-react-native/index.js
+cp ../reactotron-core-client/dist/index.js node_modules/reactotron-core-client/index.js

--- a/packages/demo-react-native/hacksetup.sh
+++ b/packages/demo-react-native/hacksetup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-npm i --save $(PWD)/../reactotron-core-client
-npm i --save $(PWD)/../reactotron-react-native

--- a/packages/demo-react-native/package.json
+++ b/packages/demo-react-native/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "copy-internal-deps": "./copy-internal-deps.sh"
   },
   "dependencies": {
     "apisauce": "^0.3.0",
@@ -12,11 +13,12 @@
     "react": "15.2.1",
     "react-native": "0.30.0",
     "react-redux": "^4.4.5",
-    "reactotron-core-client": "file:///Users/steve/src/reactotron/packages/reactotron-core-client",
-    "reactotron-react-native": "file:///Users/steve/src/reactotron/packages/reactotron-react-native",
     "redux": "^3.5.1",
     "redux-logger": "^2.6.1",
     "redux-saga": "^0.11.0",
-    "seamless-immutable": "^6.0.1"
+    "seamless-immutable": "^6.0.1",
+    "socket.io": "^1.4.8",
+    "reactotron-core-client": "^0.0.1",
+    "reactotron-react-native": "^0.0.1"
   }
 }

--- a/packages/reactotron-react-native/package.json
+++ b/packages/reactotron-react-native/package.json
@@ -21,6 +21,9 @@
     "LICENSE",
     "README.md"
   ],
+  "peerDependenciese": {
+    "react-native": ">=0.30.0"
+  },
   "devDependencies": {
     "ava": "^0.15.2",
     "babel-core": "^6.11.4",

--- a/packages/reactotron-react-native/package.json
+++ b/packages/reactotron-react-native/package.json
@@ -21,7 +21,7 @@
     "LICENSE",
     "README.md"
   ],
-  "peerDependenciese": {
+  "peerDependencies": {
     "react-native": ">=0.30.0"
   },
   "devDependencies": {

--- a/scripts/welcome.sh
+++ b/scripts/welcome.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo "-=-=-=-=-=-=-=-=-="
+echo "Welcome Developers"
+echo "-=-=-=-=-=-=-=-=-="
+echo ""
+echo "Let's get your build environment ready."
+echo ""
+echo "This will take about 5 minutes because.... well... npm.  amirite???"
+echo ""
+echo ""
+npm run bootstrap
+npm run build
+npm run copy-internal-deps
+npm test


### PR DESCRIPTION
Although not the preferred solution, this gets us going until React Native is able to support symlink'ed node_modules.

I tried symlinks, npm link, lerna's proxy approach, multiple --root folders... everything bombed.

There's a PR in React Native to deal with this that looks like it's being merged shortly, but this has been an known issue since May 2015.  :)

Oh well.  This manual copying works, but looking forward to removing this.

TL;DR:  `npm run welcome` in the root directory to get started.