### PR TITLE
Adds a "close enough" stopwatch utility.

### DIFF
--- a/packages/demo-react-native/App/Sagas/WeatherSaga.js
+++ b/packages/demo-react-native/App/Sagas/WeatherSaga.js
@@ -7,8 +7,10 @@ import Reactotron from 'reactotron-react-native'
 const SCALE = 'C'
 
 export function * getWeather (api, city) {
+  const elapsed = Reactotron.startTimer()
   // const bench = Reactotron.bench('weather check')
   const response = yield call(api.get, '/find/name', { q: city })
+  Reactotron.log(`api call took ${elapsed()} ms`)
   // bench.step('after api')
   if (response.ok) {
     const kelvin = RS.dotPath('data.list.0.main.temp', response)

--- a/packages/reactotron-core-client/README.md
+++ b/packages/reactotron-core-client/README.md
@@ -143,6 +143,11 @@ client.send('bench.report', {
   ]
 })
 
+// a utility to time things
+const elapsed = client.startTimer()
+// do something you want to time
+const ms = elapsed()  // the number of ms it took.  ish.
+
 ```
 
 # Why are we passing socket.io down?

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -1,6 +1,7 @@
 import R from 'ramda'
 import validate from './validate'
 import pluginLog from './plugin-log'
+import { start } from './stopwatch'
 
 const DEFAULTS = {
   io: null, // the socket.io function to create a socket
@@ -19,7 +20,8 @@ export const CorePlugins = [
 // these are not for you.
 const isReservedFeature = R.contains(R.__, [
   'options', 'connected', 'socket', 'plugins',
-  'configure', 'connect', 'send', 'addPlugin'
+  'configure', 'connect', 'send', 'addPlugin',
+  'startTimer'
 ])
 
 export class Client {
@@ -29,6 +31,8 @@ export class Client {
   connected = false
   socket = null
   plugins = []
+
+  startTimer = () => start()
 
   /**
    * Set the configuration options.

--- a/packages/reactotron-core-client/src/stopwatch.js
+++ b/packages/reactotron-core-client/src/stopwatch.js
@@ -1,0 +1,37 @@
+const hasHirezNodeTimer = false && typeof process === 'object' && process && process.hrtime && typeof process.hrtime === 'function'
+
+// the default timer
+const defaultPerformanceNow = () => Date.now()
+
+// try to find the browser-based performance timer
+const nativePerformance = typeof window !== 'undefined' && window && (window.performance || window.msPerformance || window.webkitPerformance)
+
+// if we do find it, let's setup to call it
+const nativePerformanceNow = () => nativePerformance.now()
+
+// the function we're trying to assign
+let performanceNow = defaultPerformanceNow
+
+// accepts an already started time and returns the number of milliseconds
+let delta = started => performanceNow() - started
+
+// node will use a high rez timer
+if (hasHirezNodeTimer) {
+  performanceNow = process.hrtime
+  delta = started => performanceNow(started)[1] / 1000000
+} else if (nativePerformance) {
+  performanceNow = nativePerformanceNow
+}
+
+// this is the interface the callers will use
+// export const performanceNow = nativePerformance ? nativePerformanceNow : defaultPerformanceNow
+
+/**
+ * Starts a lame, low-res timer.  Returns a function which when invoked,
+ * gives you the number of milliseconds since passing.  ish.
+ */
+export const start = () => {
+  //  record the start time
+  const started = performanceNow()
+  return () => delta(started)
+}

--- a/packages/reactotron-core-client/test/plugin-features-test.js
+++ b/packages/reactotron-core-client/test/plugin-features-test.js
@@ -14,7 +14,7 @@ test('some names are not allowed', t => {
 
   const badPlugins = R.map(
     name => createPlugin({ [name]: R.identity }),
-    ['options', 'connected', 'socket', 'plugins', 'configure', 'connect', 'send', 'addPlugin']
+    ['options', 'connected', 'socket', 'plugins', 'configure', 'connect', 'send', 'addPlugin', 'startTimer']
   )
 
   R.forEach(plugin => {

--- a/packages/reactotron-core-client/test/start-timer-test.js
+++ b/packages/reactotron-core-client/test/start-timer-test.js
@@ -1,0 +1,10 @@
+import test from 'ava'
+import { createClient } from '../src'
+import io from './_fake-io'
+
+test('has a startTimer function', t => {
+  const client = createClient({ io })
+  t.is(typeof client.startTimer, 'function')
+  const elapsed = client.startTimer()
+  t.is(typeof elapsed, 'function')
+})

--- a/packages/reactotron-core-client/test/stopwatch-test.js
+++ b/packages/reactotron-core-client/test/stopwatch-test.js
@@ -1,0 +1,32 @@
+import test from 'ava'
+import { start } from '../src/stopwatch'
+
+// aim for 30 fps -- even though fps has nothing to do with anything at all
+const TICK = 1.0 / 30.0
+
+// a promise based delay that's not accurate at all
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+test('start returns the right interface', t => {
+  const elapsed = start()
+  t.is(typeof elapsed, 'function')
+})
+
+// using >= because on node there's event loop overhead and new Date() instantiation
+test('gives us milliseconds', async t => {
+  const elapsed = start()
+  t.true(elapsed() <= 0.1) // just a sanity test to make sure i'm not the problem
+  await delay(TICK)
+  t.true(elapsed() >= TICK)
+  await delay(TICK)
+  t.true(elapsed() >= TICK * 2)
+})
+
+// here's a callback version
+test.cb('gives us milliseconds', t => {
+  const elapsed = start()
+  setTimeout(() => {
+    t.true(elapsed() >= TICK)
+    t.end()
+  }, TICK)
+})


### PR DESCRIPTION
A node & react-native (sim & device) friendly way to calculate time.  Will be using this for the plugins, so I just hung it on the client instance.

```js
const elapsed = client.startTimer()
// ... stuff 
const ms = elapsed()
```

The resolution on node is perfect, but once you call `setTimeout` on any platform, it goes south.

Most js execution engines don't guarantee the ms on `setTimeout`.  
And by most, I mean all.  
And by all, I only tested on 4.  
And by 4 I mean 3.

:shipit: 