### PR TITLE
Updates the plugin interface to accept a config object.

### DIFF
--- a/packages/reactotron-core-client/README.md
+++ b/packages/reactotron-core-client/README.md
@@ -380,15 +380,20 @@ Sent from the client to server when it's time to report some performance details
 Reactotron is extensible via plugins.  You add plugins by calling the `addPlugin`
 function on the the client.
 
-A plugin is a function with 1 parameter: a function called send.  It returns an
+A plugin is a function with 1 parameter: a configuration object.  It returns an
 object.
+
+The inbound object has two keys:
+
+* send - call this function to send messages
+* ref - a reference to the client (danger... it's not bound properly, use send instead)
 
 Should the object have certain keynames, then those functions will get invoked
 at the right time.
 
 ```js
 // counter-plugin.js
-export default send => {
+export default config => {
   let commandCounter = 0
   return {
     onCommand: command => {

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -110,7 +110,10 @@ export class Client {
     if (typeof pluginCreator !== 'function') throw new Error('plugins must be a function')
 
     // execute it immediately passing the send function
-    const plugin = pluginCreator(this.send.bind(this))
+    const plugin = pluginCreator({
+      send: this.send.bind(this),
+      ref: this
+    })
 
     // ensure we get an Object-like creature back
     if (!R.is(Object, plugin)) throw new Error('plugins must return an object')

--- a/packages/reactotron-core-client/src/plugin-log.js
+++ b/packages/reactotron-core-client/src/plugin-log.js
@@ -1,7 +1,7 @@
 /**
  * Provides 4 features for logging.  log & debug are the same.
  */
-export default (send) => {
+export default ({ send }) => {
   return {
     features: {
       log: (message) => send('log', { level: 'debug', message }),

--- a/packages/reactotron-core-client/test/configure-test.js
+++ b/packages/reactotron-core-client/test/configure-test.js
@@ -2,8 +2,6 @@ import test from 'ava'
 import { createClient } from '../src'
 import io from './_fake-io'
 
-const onCommand = (type, payload) => true
-
 test('has defaults', t => {
   const client = createClient({io})
   t.is(client.options.host, 'localhost')

--- a/packages/reactotron-core-client/test/plugin-features-test.js
+++ b/packages/reactotron-core-client/test/plugin-features-test.js
@@ -5,12 +5,12 @@ import R from 'ramda'
 
 test('features must be an object if they appear', t => {
   const client = createClient({ io })
-  t.throws(() => client.addPlugin(send => ({ features: 1 })))
+  t.throws(() => client.addPlugin(config => ({ features: 1 })))
 })
 
 test('some names are not allowed', t => {
   const client = createClient({ io })
-  const createPlugin = features => send => ({features})
+  const createPlugin = features => config => ({features})
 
   const badPlugins = R.map(
     name => createPlugin({ [name]: R.identity }),
@@ -24,7 +24,7 @@ test('some names are not allowed', t => {
 
 test('features can be added and called', t => {
   const client = createClient({ io })
-  const plugin = send => {
+  const plugin = config => {
     const features = {
       magic: () => 42
     }
@@ -37,7 +37,7 @@ test('features can be added and called', t => {
 
 test('you can overwrite other feature names', t => {
   const client = createClient({ io })
-  const createPlugin = number => send => ({ features: { hello: () => number } })
+  const createPlugin = number => config => ({ features: { hello: () => number } })
   client.addPlugin(createPlugin(69))
   t.is(client.hello(), 69)
   client.addPlugin(createPlugin(9001))

--- a/packages/reactotron-core-client/test/plugin-interface-test.js
+++ b/packages/reactotron-core-client/test/plugin-interface-test.js
@@ -28,15 +28,17 @@ test('plugins are invoke and return an object', t => {
 
 test('plugins can literally do nothing', t => {
   const client = createClient({ io })
-  const empty = send => ({})
+  const empty = config => ({})
   client.addPlugin(empty)
   t.is(client.plugins.length, 1)
 })
 
-test.cb('initialized with a send function', t => {
+test.cb('initialized with the config object', t => {
   const client = createClient({ io })
-  client.addPlugin(send => {
-    t.true(typeof send === 'function')
+  client.addPlugin(config => {
+    t.is(typeof config, 'object')
+    t.is(config.ref, client)
+    t.is(typeof config.send, 'function')
     t.end()
     return {}
   })
@@ -44,7 +46,7 @@ test.cb('initialized with a send function', t => {
 })
 
 test('can be added in createClient', t => {
-  const createPlugin = (name, value) => send => ({ features: { [name]: () => value } })
+  const createPlugin = (name, value) => config => ({ features: { [name]: () => value } })
   const client = createClient({
     io,
     plugins: [

--- a/packages/reactotron-core-client/test/plugin-log-test.js
+++ b/packages/reactotron-core-client/test/plugin-log-test.js
@@ -1,0 +1,33 @@
+import test from 'ava'
+import { createClient } from '../src'
+import socketClient from 'socket.io-client'
+import plugin from '../src/plugin-log'
+
+test('the 4 functions send the right data', t => {
+  const client = createClient({ io: socketClient })
+  const results = []
+  client.send = (type, payload) => { results.push({type, payload}) }
+  client.addPlugin(plugin)
+  t.is(client.plugins.length, 1)
+  t.is(typeof client.log, 'function')
+  t.is(typeof client.debug, 'function')
+  t.is(typeof client.warn, 'function')
+  t.is(typeof client.error, 'function')
+  client.log('a')
+  client.debug('b')
+  client.warn('c')
+  client.error('d')
+  t.is(results.length, 4)
+  t.is(results[0].type, 'log')
+  t.is(results[1].type, 'log')
+  t.is(results[2].type, 'log')
+  t.is(results[3].type, 'log')
+  t.is(results[0].payload.level, 'debug')
+  t.is(results[1].payload.level, 'debug')
+  t.is(results[2].payload.level, 'warn')
+  t.is(results[3].payload.level, 'error')
+  t.is(results[0].payload.message, 'a')
+  t.is(results[1].payload.message, 'b')
+  t.is(results[2].payload.message, 'c')
+  t.is(results[3].payload.message, 'd')
+})

--- a/packages/reactotron-core-client/test/plugin-on-command-test.js
+++ b/packages/reactotron-core-client/test/plugin-on-command-test.js
@@ -12,8 +12,8 @@ test.cb('plugins support send', t => {
   let capturedSend
 
   // the plugin to extract the send function
-  const plugin = send => {
-    capturedSend = send
+  const plugin = config => {
+    capturedSend = config.send
     return {}
   }
 


### PR DESCRIPTION
Upgrades plugins initialization from just a `send` function to an object.

A little more flexible.

`.send` is still there, however, `.ref` is there now too, in case plugins need it.