### PR TITLE
Resends the subscribed values when a fresh client connects.

### DIFF
--- a/packages/reactotron-cli/src/index.js
+++ b/packages/reactotron-cli/src/index.js
@@ -19,6 +19,7 @@ const server = createServer({
   },
   onConnect: client => {
     context.post({ type: 'client.add', client })
+    context.post({ type: 'redux.subscribe.request' })
   },
   onDisconnect: client => {
     context.post({ type: 'client.remove', client })


### PR DESCRIPTION
Ok.  It's time to move this server functionality back to `reactotron-core-server`.  Finally get to get my mobx on.!